### PR TITLE
Add flag to force CLIENT composition for YUV layers

### DIFF
--- a/base/libhwc2.1/Android.bp
+++ b/base/libhwc2.1/Android.bp
@@ -82,6 +82,9 @@ cc_defaults {
     }) + select(soong_config_variable("exynos_hwc", "uses_hwc_services"), {
         "true": [ "-DUSES_HWC_SERVICES" ],
         default: [],
+    }) + select(soong_config_variable("exynos_hwc", "HWC_FORCE_CLIENT_VIDEO"), {
+        "true": ["-DHWC_FORCE_CLIENT_VIDEO"],
+        default: [],
     }),
 
     static_libs: [

--- a/base/libhwc2.1/device/ExynosResourceManager.cpp
+++ b/base/libhwc2.1/device/ExynosResourceManager.cpp
@@ -992,6 +992,22 @@ int32_t ExynosResourceManager::validateLayer(uint32_t index, ExynosDisplay *disp
         (layer->mPreprocessedInfo.displayFrame.bottom > (int32_t)display->mYres))
         return eInvalidDispFrame;
 
+#ifdef HWC_FORCE_CLIENT_VIDEO
+    /*
+     * When the flag HWC_FORCE_CLIENT_VIDEO is enabled, force all YUV (usually video)
+     * layers to CLIENT composition to avoid hardware overlay artifacts.
+     */
+    {
+        if (layer->mLayerBuffer != NULL) {
+            exynos_image __tmp_img;
+            layer->setSrcExynosImage(&__tmp_img);
+            if (__tmp_img.exynosFormat.isYUV()) {
+                return eFroceClientLayer;
+            }
+        }
+    }
+#endif
+
     return NO_ERROR;
 }
 


### PR DESCRIPTION
At the moment, when DEVICE composition is used for scaled video in s5e8825, green artifacts cover the whole video. This can be worked around by enabling "Disable HW Overlays" or setting BOARD_USES_HWC_FORCE_GPU := true, but that would cause a performance hit on the whole UI.

This patch forces CLIENT composition only for YUV layers (which are usually video) and avoids that performance issue.